### PR TITLE
Trying to fix Linux automatic builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ addons:
     - linux-libc-dev:i386
     - libmysqlclient-dev:i386
     - libmysql++3:i386
-    - gcc-4.6-multilib
-    - g++-4.6-multilib
+    - gcc-4.8-multilib
+    - g++-4.8-multilib
 before_install:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 script:


### PR DESCRIPTION
Travis-CI servers got updated from Ubuntu 12.04 LTS (precise) to 14.04 LTS (trusty), breaking Sphere compiler. Probably this was caused by some incompatibility on Ubuntu packages, so let's update these packages to check if it works